### PR TITLE
Agrega endpoint para delete de servicios y arregla bugs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.github</groupId>
 	<artifactId>firulapp</artifactId>
-	<version>0.3.1</version>
+	<version>0.3.2</version>
 	<name>firulapp-backend</name>
 	<description>Backend Project for Firulapp</description>
 	<properties>

--- a/src/main/java/com/github/firulapp/service/ServiceService.java
+++ b/src/main/java/com/github/firulapp/service/ServiceService.java
@@ -19,4 +19,6 @@ public interface ServiceService {
     List<ServiceDetailsDto> getServicesByServiceType(Long serviceTypeId);
 
     List<ServiceDetailsDto> getServicesByUserId(Long userId);
+
+    void deleteService(Long serviceId) throws ServiceEntityException;
 }

--- a/src/main/java/com/github/firulapp/service/ServiceSpeciesService.java
+++ b/src/main/java/com/github/firulapp/service/ServiceSpeciesService.java
@@ -15,4 +15,6 @@ public interface ServiceSpeciesService {
     ServiceSpecies getServiceBySpeciesIdAndServiceId(Long serviceId, Long speciesId);
 
     List<ServiceSpecies> saveServiceSpeciesByServiceId(Long serviceId, List<Long> speciesIdList);
+
+    void deleteServiceSpecies(Long serviceId);
 }

--- a/src/main/java/com/github/firulapp/service/impl/ServiceServiceImpl.java
+++ b/src/main/java/com/github/firulapp/service/impl/ServiceServiceImpl.java
@@ -41,7 +41,7 @@ public class ServiceServiceImpl implements ServiceService {
             for (ServiceSpecies serviceSpecies : serviceSpeciesService.getSpeciesByServiceId(entity.getId())) {
                 species.add(serviceSpecies.getSpeciesId());
             }
-            if(species.size() != service.getSpecies().size() || !species.equals(service.getSpecies())){
+            if(species.size() != service.getSpecies().size() || !species.equals(service.getSpecies()) || !species.isEmpty()){
                 serviceSpeciesService.deleteServiceSpecies(entity.getId());
                 serviceSpeciesService.saveServiceSpeciesByServiceId(entity.getId(), service.getSpecies());
             }

--- a/src/main/java/com/github/firulapp/service/impl/ServiceServiceImpl.java
+++ b/src/main/java/com/github/firulapp/service/impl/ServiceServiceImpl.java
@@ -12,15 +12,11 @@ import com.github.firulapp.service.ServiceService;
 import com.github.firulapp.service.ServiceSpeciesService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import static java.util.Comparator.comparingInt;
-import static java.util.stream.Collectors.collectingAndThen;
-import static java.util.stream.Collectors.toCollection;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 @Service
@@ -40,12 +36,22 @@ public class ServiceServiceImpl implements ServiceService {
         ServiceDto serviceDto = service.getServiceDto();
         if(serviceDto.getId() != null) {
             serviceDto.setModifiedAt(LocalDateTime.now());
+            ServiceEntity entity = serviceEntityRepository.save(serviceMapper.mapToEntity(serviceDto));
+            ArrayList<Long> species = new ArrayList<>();
+            for (ServiceSpecies serviceSpecies : serviceSpeciesService.getSpeciesByServiceId(entity.getId())) {
+                species.add(serviceSpecies.getSpeciesId());
+            }
+            if(species.size() != service.getSpecies().size() || !species.equals(service.getSpecies())){
+                serviceSpeciesService.deleteServiceSpecies(entity.getId());
+                serviceSpeciesService.saveServiceSpeciesByServiceId(entity.getId(), service.getSpecies());
+            }
+            service.setServiceDto(serviceMapper.mapToDto(entity));
         }else{
             serviceDto.setCreatedAt(LocalDateTime.now());
+            ServiceEntity entity = serviceEntityRepository.save(serviceMapper.mapToEntity(serviceDto));
+            serviceSpeciesService.saveServiceSpeciesByServiceId(entity.getId(), service.getSpecies());
+            service.setServiceDto(serviceMapper.mapToDto(entity));
         }
-        ServiceEntity entity = serviceEntityRepository.save(serviceMapper.mapToEntity(serviceDto));
-        service.setServiceDto(serviceMapper.mapToDto(entity));
-        serviceSpeciesService.saveServiceSpeciesByServiceId(entity.getId(), service.getSpecies());
         return service;
     }
 
@@ -63,12 +69,17 @@ public class ServiceServiceImpl implements ServiceService {
 
     @Override
     public List<ServiceDetailsDto> getServicesByFilter(ServiceFilterDto serviceFilterDto) {
-        List<ServiceDto> dtos = serviceMapper.mapAsList(serviceEntityRepository
-                .findByServiceTypeIdAndSpecies(serviceFilterDto.getServiceTypeId(), serviceFilterDto.getSpeciesId()));
-
-        List<ServiceDto> uniqueDtos = dtos.stream().distinct().collect(Collectors.toList());
-
-        return getListOfServiceDetails(uniqueDtos);
+        Long serviceTypeId = serviceFilterDto.getServiceTypeId();
+        if(serviceFilterDto.getSpeciesId() != null){
+            if(!serviceFilterDto.getSpeciesId().isEmpty()) {
+                ArrayList<Long> species = serviceFilterDto.getSpeciesId();
+                List<ServiceDto> dtos = serviceMapper.mapAsList(serviceEntityRepository
+                        .findByServiceTypeIdAndSpecies(serviceTypeId, species));
+                List<ServiceDto> uniqueDtos = dtos.stream().distinct().collect(Collectors.toList());
+                return getListOfServiceDetails(uniqueDtos);
+            }
+        }
+        return getServicesByServiceType(serviceTypeId);
     }
 
     @Override
@@ -112,5 +123,11 @@ public class ServiceServiceImpl implements ServiceService {
             serviceDetailsList.add(serviceDetailsDto);
         }
         return serviceDetailsList;
+    }
+
+    @Override
+    public void deleteService(Long serviceId) throws ServiceEntityException {
+        serviceSpeciesService.deleteServiceSpecies(serviceId);
+        serviceEntityRepository.delete(serviceMapper.mapToEntity(getServiceById(serviceId).getServiceDto()));
     }
 }

--- a/src/main/java/com/github/firulapp/service/impl/ServiceSpeciesServiceImpl.java
+++ b/src/main/java/com/github/firulapp/service/impl/ServiceSpeciesServiceImpl.java
@@ -46,4 +46,12 @@ public class ServiceSpeciesServiceImpl implements ServiceSpeciesService {
         }
         return serviceSpeciesList;
     }
+
+    @Override
+    public void deleteServiceSpecies(Long serviceId) {
+        List<ServiceSpecies> serviceSpecies = getSpeciesByServiceId(serviceId);
+        for (ServiceSpecies s:serviceSpecies) {
+            serviceSpeciesRepository.delete(s);
+        }
+    }
 }

--- a/src/main/java/com/github/firulapp/util/EmailUtils.java
+++ b/src/main/java/com/github/firulapp/util/EmailUtils.java
@@ -1,8 +1,9 @@
 package com.github.firulapp.util;
 
-import com.github.firulapp.domain.AppUserDetails;
 import com.github.firulapp.domain.Pet;
-import com.github.firulapp.dto.*;
+import com.github.firulapp.dto.AppUserProfileDto;
+import com.github.firulapp.dto.CityDto;
+import com.github.firulapp.dto.PetDto;
 import com.github.firulapp.exceptions.EmailUtilsException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/com/github/firulapp/web/controller/ServiceController.java
+++ b/src/main/java/com/github/firulapp/web/controller/ServiceController.java
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.*;
 
 @Controller
@@ -48,8 +49,18 @@ public class ServiceController {
         return ResponseEntity.ok(ListResponseDTO.success(serviceService.getServicesByUserId(id)));
     }
 
-    @GetMapping(value = ApiPaths.SERVICE_FILTER)
+    @PostMapping(value = ApiPaths.SERVICE_FILTER)
     public ResponseEntity<ListResponseDTO> getServicesByFilters(@RequestBody ServiceFilterDto filterDto){
         return ResponseEntity.ok(ListResponseDTO.success(serviceService.getServicesByFilter(filterDto)));
+    }
+
+    @DeleteMapping(value = ApiPaths.ID)
+    public ResponseEntity<Void> deleteService(@PathVariable Long id){
+        try {
+            serviceService.deleteService(id);
+            return new ResponseEntity<>(HttpStatus.OK);
+        }catch (ServiceEntityException exception){
+            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+        }
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,8 +16,8 @@ spring.jpa.properties.hibernate.temp.use_jdbc_metadata_defaults=false
 spring.jpa.database=POSTGRESQL
 spring.jpa.properties.hibernate.format_sql=true
 
-mail.smtp.user=jazvillagra.jv@fpuna.edu.py
-mail.smtp.password=bW9ua2V5IGJyYTFueg==
+mail.smtp.user=
+mail.smtp.password=
 mail.smtp.auth=true
 mail.smtp.starttls.enable=true
 mail.smtp.host=smtp.gmail.com


### PR DESCRIPTION
- DELETE `/api/service/{id}` . Si no existe el id, tira un error 401 BAD REQUEST
- POST `/api/service/filter` recibe `@RequestBody ServiceFilterDto dto` donde:
  - ServiceFilterDto:
    - `{"serviceTypeId": 1, "species": [1,2,3]}`
    - serviceTypeId no puede ser null
    - species puede ser null, contener un array vacio o un array con números enteros